### PR TITLE
Merge dev_desugar into master

### DIFF
--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/Grammar.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/Grammar.java
@@ -225,7 +225,11 @@ public class Grammar {
         }
     }
 
-    public String getStartRule() {
+    public Rule getStartRule() {
+        return startRule;
+    }
+
+    public String getStartRuleName() {
         return startRuleName;
     }
 

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/Grammar.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/Grammar.java
@@ -33,9 +33,6 @@ public class Grammar {
     private boolean linkageDone;
     private TokenizerTypeList additionalTokenTypes;
 
-    private boolean hasSugar;
-    private boolean checkedSugar;
-
     public static Builder newBuilder(File grammarFile) {
         return new Builder(grammarFile);
     }
@@ -84,9 +81,6 @@ public class Grammar {
         linkageDone = false;
         additionalTokenTypes = new TokenizerTypeList();
 
-        hasSugar = false;
-        checkedSugar = false;
-
         String fullText;
         try {
             fullText = Files.readString(builder.grammarFile.toPath());
@@ -134,8 +128,6 @@ public class Grammar {
         } else {
             setStart(builder.startSymbol);
         }
-
-        checkSugar();
     }
 
     public TokenizerTypeList getRegexTokenTypes() {
@@ -290,28 +282,6 @@ public class Grammar {
             n--;
         }
         return classification;
-    }
-
-    private void checkSugar() {
-        if (checkedSugar) {
-            return;
-        }
-        checkedSugar = true;
-
-        hasSugar = false;
-        for (Rule rule : rules) {
-            rule.checkSugar();
-            if (rule.hasSugar()) {
-                hasSugar = true;
-            }
-        }
-    }
-
-    public boolean hasSugar() {
-        if (!checkedSugar) {
-            checkSugar();
-        }
-        return hasSugar;
     }
 
     public Token getNextIdentifier(String identifier) {

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/Grammar.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/Grammar.java
@@ -17,6 +17,8 @@ import java.util.Set;
 import java.util.function.Function;
 
 import com.blamedcloud.parsertongue.grammar.expecterator.ParseResultExpecterator;
+import com.blamedcloud.parsertongue.grammar.result.ParseResult;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.smallstrings.SmallestStringIterator;
 import com.blamedcloud.parsertongue.tokenizer.Token;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/GrammarSaver.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/GrammarSaver.java
@@ -1,0 +1,63 @@
+package com.blamedcloud.parsertongue.grammar;
+
+public class GrammarSaver {
+
+    public static final String DEFAULT_RULE_SPLIT = "\n";
+    public static final String DEFAULT_TOKEN_SPLIT = " ";
+
+    public static String saveGrammar(Grammar grammar) {
+        String grammarString = "";
+
+        grammarString += saveRule(grammar.getStartRule());
+
+        for (Rule rule : grammar.getRules()) {
+            if (!rule.lhs().getValue().equals(grammar.getStartRuleName())) {
+                grammarString += DEFAULT_RULE_SPLIT + saveRule(rule);
+            }
+        }
+
+        return grammarString;
+    }
+
+    public static String saveRule(Rule rule) {
+        String ruleString = rule.lhs().getValue() + DEFAULT_TOKEN_SPLIT + '=' + DEFAULT_TOKEN_SPLIT;
+        if (rule.hasDependency()) {
+            ruleString += rule.getDependencyName() + DEFAULT_TOKEN_SPLIT + ":" + DEFAULT_TOKEN_SPLIT;
+        } else if (rule.isRegexRule()) {
+            ruleString += "~" + DEFAULT_TOKEN_SPLIT;
+        }
+        ruleString += saveRHS(rule.rhs());
+        ruleString += DEFAULT_TOKEN_SPLIT + ";" + DEFAULT_RULE_SPLIT;
+
+        return ruleString;
+    }
+
+    public static String saveRHS(RHSTree tree) {
+        String treeString = "";
+
+        RHSType type = tree.getType();
+        if (type == RHSType.IDENTIFIER) {
+            treeString = tree.getNode().getValue();
+        } else if (type == RHSType.TERMINAL) {
+            treeString = '"' + tree.getNode().getValue() + '"';
+        } else if (type == RHSType.REGEX) {
+            treeString = '"' + tree.getRegexNode().getExpression() + '"';
+        } else if (type == RHSType.GROUP) {
+            treeString = "(" + saveRHS(tree.getChild()) + ")";
+        } else if (type == RHSType.OPTIONAL) {
+            treeString = "[" + saveRHS(tree.getChild()) + "]";
+        } else if (type == RHSType.REPEAT) {
+            treeString = "{" + saveRHS(tree.getChild()) + "}";
+        } else if (type == RHSType.ALTERNATION || type == RHSType.CONCATENATION) {
+            String separator = DEFAULT_TOKEN_SPLIT + (type == RHSType.ALTERNATION ? "|" : ",") + DEFAULT_TOKEN_SPLIT;
+            // iterate over all but the last child
+            for (int i = 0; i < tree.size() - 1; i++) {
+                RHSTree child = tree.getChild(i);
+                treeString += saveRHS(child) + separator;
+            }
+            treeString += saveRHS(tree.getChild(tree.size()-1));
+        }
+
+        return treeString;
+    }
+}

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/RHSTree.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/RHSTree.java
@@ -32,11 +32,6 @@ public class RHSTree {
     private TokenType regexNode;
     private Rule link;
 
-
-    private boolean hasDirectSugar;
-    private boolean hasNestedSugar;
-    private boolean checkedSugar;
-
     public RHSTree(RHSType type) {
         levelType = type;
         levelKind = type.getKind();
@@ -44,10 +39,6 @@ public class RHSTree {
         node = null;
         regexNode = null;
         link = null;
-
-        hasDirectSugar = false;
-        hasNestedSugar = false;
-        checkedSugar = false;
     }
 
     public void addChild(RHSTree child) {
@@ -257,48 +248,4 @@ public class RHSTree {
         return new WalkResult(isInfinite, treeSize);
     }
 
-    protected void checkSugar() {
-        if (checkedSugar) {
-            return;
-        }
-        checkedSugar = true;
-
-        hasDirectSugar = false;
-        hasNestedSugar = false;
-
-        if (levelKind == RHSKind.SINGLE) {
-            hasDirectSugar = true;
-        }
-
-        if (levelKind == RHSKind.SINGLE || levelKind == RHSKind.LIST) {
-            for (RHSTree child : children) {
-                child.checkSugar();
-                if (child.hasSugar()) {
-                    hasNestedSugar = true;
-                }
-            }
-        }
-
-        if (levelType == RHSType.IDENTIFIER) {
-            link.checkSugar();
-            if (link.hasSugar()) {
-                hasNestedSugar = true;
-            }
-        }
-    }
-
-    public boolean hasSugar() {
-        if (!checkedSugar) {
-            checkSugar();
-        }
-        return hasDirectSugar || hasNestedSugar;
-    }
-
-    protected void deSugar(Grammar grammar, Rule parent) {
-        if (!hasSugar()) {
-            return;
-        }
-
-
-    }
 }

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/RHSTree.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/RHSTree.java
@@ -25,7 +25,7 @@ public class RHSTree {
     private RHSKind levelKind;
     private RHSType levelType;
 
-    // which of these are defined depends on
+    // which of these are valid depends on
     // the levelKind and levelType of this tree.
     private List<RHSTree> children;
     private Token node;
@@ -132,6 +132,10 @@ public class RHSTree {
 
     public RHSTree getChild(int index) {
         return children.get(index);
+    }
+
+    public List<RHSTree> getChildren() {
+        return children;
     }
 
     public Token getNode() {
@@ -246,6 +250,27 @@ public class RHSTree {
             }
         }
         return new WalkResult(isInfinite, treeSize);
+    }
+
+    // note that the copy returned will not be linked.
+    public RHSTree copy() {
+        RHSTree newTree = new RHSTree(levelType);
+
+        if (levelKind == RHSKind.LIST || levelKind == RHSKind.SINGLE) {
+            for (RHSTree child : children) {
+                newTree.addChild(child.copy());
+            }
+        }
+
+        if (levelKind == RHSKind.LEAF) {
+            if (levelType == RHSType.REGEX) {
+                newTree.createRegexNode(regexNode);
+            } else {
+                newTree.createNode(node);
+            }
+        }
+
+        return newTree;
     }
 
 }

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/RHSTree.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/RHSTree.java
@@ -21,12 +21,21 @@ import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 
 public class RHSTree {
 
+    // all RHSTree's have a kind and a type
+    private RHSKind levelKind;
     private RHSType levelType;
+
+    // which of these are defined depends on
+    // the levelKind and levelType of this tree.
     private List<RHSTree> children;
     private Token node;
     private TokenType regexNode;
-    private RHSKind levelKind;
     private Rule link;
+
+
+    private boolean hasDirectSugar;
+    private boolean hasNestedSugar;
+    private boolean checkedSugar;
 
     public RHSTree(RHSType type) {
         levelType = type;
@@ -35,6 +44,10 @@ public class RHSTree {
         node = null;
         regexNode = null;
         link = null;
+
+        hasDirectSugar = false;
+        hasNestedSugar = false;
+        checkedSugar = false;
     }
 
     public void addChild(RHSTree child) {
@@ -244,4 +257,48 @@ public class RHSTree {
         return new WalkResult(isInfinite, treeSize);
     }
 
+    protected void checkSugar() {
+        if (checkedSugar) {
+            return;
+        }
+        checkedSugar = true;
+
+        hasDirectSugar = false;
+        hasNestedSugar = false;
+
+        if (levelKind == RHSKind.SINGLE) {
+            hasDirectSugar = true;
+        }
+
+        if (levelKind == RHSKind.SINGLE || levelKind == RHSKind.LIST) {
+            for (RHSTree child : children) {
+                child.checkSugar();
+                if (child.hasSugar()) {
+                    hasNestedSugar = true;
+                }
+            }
+        }
+
+        if (levelType == RHSType.IDENTIFIER) {
+            link.checkSugar();
+            if (link.hasSugar()) {
+                hasNestedSugar = true;
+            }
+        }
+    }
+
+    public boolean hasSugar() {
+        if (!checkedSugar) {
+            checkSugar();
+        }
+        return hasDirectSugar || hasNestedSugar;
+    }
+
+    protected void deSugar(Grammar grammar, Rule parent) {
+        if (!hasSugar()) {
+            return;
+        }
+
+
+    }
 }

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/Rule.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/Rule.java
@@ -145,21 +145,6 @@ public class Rule {
         return currentTokenType().isSameAs(getTTByName(name));
     }
 
-    protected void checkSugar() {
-        rhsTree.checkSugar();
-    }
-
-    public boolean hasSugar() {
-        return rhsTree.hasSugar();
-    }
-
-    protected void deSugar(Grammar grammar) {
-        if (!hasSugar()) {
-            return;
-        }
-        rhsTree.deSugar(grammar, this);
-    }
-
     private void parseRule() {
         if (ruleTokens.size() < MIN_TOKEN_COUNT) {
             throw new RuntimeException("Rule has too few tokens");

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/Rule.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/Rule.java
@@ -25,6 +25,8 @@ import java.util.function.Function;
 
 import com.blamedcloud.parsertongue.grammar.expecterator.ParseResultExpecterator;
 import com.blamedcloud.parsertongue.grammar.expecterator.RuleExpecterator;
+import com.blamedcloud.parsertongue.grammar.result.ParseResult;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Token;
 import com.blamedcloud.parsertongue.tokenizer.TokenType;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/Rule.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/Rule.java
@@ -145,6 +145,21 @@ public class Rule {
         return currentTokenType().isSameAs(getTTByName(name));
     }
 
+    protected void checkSugar() {
+        rhsTree.checkSugar();
+    }
+
+    public boolean hasSugar() {
+        return rhsTree.hasSugar();
+    }
+
+    protected void deSugar(Grammar grammar) {
+        if (!hasSugar()) {
+            return;
+        }
+        rhsTree.deSugar(grammar, this);
+    }
+
     private void parseRule() {
         if (ruleTokens.size() < MIN_TOKEN_COUNT) {
             throw new RuntimeException("Rule has too few tokens");

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/AlternationExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/AlternationExpecterator.java
@@ -2,8 +2,8 @@ package com.blamedcloud.parsertongue.grammar.expecterator;
 
 import java.util.Optional;
 
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.RHSTree;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 
 public class AlternationExpecterator extends ParseResultExpecterator {

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/ConcatenationExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/ConcatenationExpecterator.java
@@ -2,9 +2,9 @@ package com.blamedcloud.parsertongue.grammar.expecterator;
 
 import java.util.Optional;
 
-import com.blamedcloud.parsertongue.grammar.ListParseResult;
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.RHSTree;
+import com.blamedcloud.parsertongue.grammar.result.ListParseResult;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 
 public class ConcatenationExpecterator extends ParseResultExpecterator {

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/GroupExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/GroupExpecterator.java
@@ -2,8 +2,8 @@ package com.blamedcloud.parsertongue.grammar.expecterator;
 
 import java.util.Optional;
 
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.RHSTree;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 
 public class GroupExpecterator extends ParseResultExpecterator {

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/IdentifierExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/IdentifierExpecterator.java
@@ -2,8 +2,8 @@ package com.blamedcloud.parsertongue.grammar.expecterator;
 
 import java.util.Optional;
 
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.RHSTree;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 
 public class IdentifierExpecterator extends ParseResultExpecterator {

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/OptionalExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/OptionalExpecterator.java
@@ -2,9 +2,9 @@ package com.blamedcloud.parsertongue.grammar.expecterator;
 
 import java.util.Optional;
 
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.RHSTree;
-import com.blamedcloud.parsertongue.grammar.StringParseResult;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
+import com.blamedcloud.parsertongue.grammar.result.StringParseResult;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 
 public class OptionalExpecterator extends ParseResultExpecterator {

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/ParseResultExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/ParseResultExpecterator.java
@@ -1,6 +1,6 @@
 package com.blamedcloud.parsertongue.grammar.expecterator;
 
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 
 public abstract class ParseResultExpecterator implements Expecterator<ParseResultTransformer> {

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/RegexExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/RegexExpecterator.java
@@ -2,9 +2,9 @@ package com.blamedcloud.parsertongue.grammar.expecterator;
 
 import java.util.Optional;
 
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.RHSTree;
-import com.blamedcloud.parsertongue.grammar.StringParseResult;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
+import com.blamedcloud.parsertongue.grammar.result.StringParseResult;
 import com.blamedcloud.parsertongue.tokenizer.TokenType;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/RepeatExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/RepeatExpecterator.java
@@ -2,9 +2,9 @@ package com.blamedcloud.parsertongue.grammar.expecterator;
 
 import java.util.Optional;
 
-import com.blamedcloud.parsertongue.grammar.ListParseResult;
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.RHSTree;
+import com.blamedcloud.parsertongue.grammar.result.ListParseResult;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 
 public class RepeatExpecterator extends ParseResultExpecterator {

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/RuleExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/RuleExpecterator.java
@@ -2,8 +2,8 @@ package com.blamedcloud.parsertongue.grammar.expecterator;
 
 import java.util.Optional;
 
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.Rule;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 
 public class RuleExpecterator extends ParseResultExpecterator {

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/TerminalExpecterator.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/expecterator/TerminalExpecterator.java
@@ -2,9 +2,9 @@ package com.blamedcloud.parsertongue.grammar.expecterator;
 
 import java.util.Optional;
 
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.RHSTree;
-import com.blamedcloud.parsertongue.grammar.StringParseResult;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
+import com.blamedcloud.parsertongue.grammar.result.StringParseResult;
 import com.blamedcloud.parsertongue.tokenizer.Token;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/result/ListParseResult.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/result/ListParseResult.java
@@ -1,4 +1,4 @@
-package com.blamedcloud.parsertongue.grammar;
+package com.blamedcloud.parsertongue.grammar.result;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/result/ParseResult.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/result/ParseResult.java
@@ -1,4 +1,4 @@
-package com.blamedcloud.parsertongue.grammar;
+package com.blamedcloud.parsertongue.grammar.result;
 
 public interface ParseResult {
 

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/result/ParseResultTransformer.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/result/ParseResultTransformer.java
@@ -1,4 +1,4 @@
-package com.blamedcloud.parsertongue.grammar;
+package com.blamedcloud.parsertongue.grammar.result;
 
 import java.util.function.Function;
 

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/result/StringParseResult.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/result/StringParseResult.java
@@ -1,4 +1,4 @@
-package com.blamedcloud.parsertongue.grammar;
+package com.blamedcloud.parsertongue.grammar.result;
 
 public class StringParseResult implements ParseResult {
 

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/transformer/GrammarTransformer.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/transformer/GrammarTransformer.java
@@ -1,0 +1,18 @@
+package com.blamedcloud.parsertongue.grammar.transformer;
+
+import com.blamedcloud.parsertongue.grammar.Grammar;
+import com.blamedcloud.parsertongue.grammar.RHSTree;
+import com.blamedcloud.parsertongue.grammar.Rule;
+
+public interface GrammarTransformer {
+
+    public Grammar getOriginalGrammar();
+
+    public boolean containsAffectedRules();
+
+    public boolean isRuleAffected(Rule rule);
+
+    public boolean isRHSAffected(Rule parent, RHSTree tree);
+
+    public Grammar getTransformedGrammar();
+}

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/transformer/SugarTransformer.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/transformer/SugarTransformer.java
@@ -1,0 +1,110 @@
+package com.blamedcloud.parsertongue.grammar.transformer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.blamedcloud.parsertongue.grammar.Grammar;
+import com.blamedcloud.parsertongue.grammar.RHSKind;
+import com.blamedcloud.parsertongue.grammar.RHSTree;
+import com.blamedcloud.parsertongue.grammar.RHSType;
+import com.blamedcloud.parsertongue.grammar.Rule;
+
+public class SugarTransformer implements GrammarTransformer {
+
+    private Grammar originalGrammar;
+
+    private boolean grammarHasSugar;
+    private Map<Rule, Boolean> ruleSugar;
+    private Map<RHSTree, Boolean> rhsDirectSugar;
+    private Map<RHSTree, Boolean> rhsNestedSugar;
+
+    public SugarTransformer(Grammar grammar) {
+        originalGrammar = grammar;
+        ruleSugar = new HashMap<>();
+        rhsDirectSugar = new HashMap<>();
+        rhsNestedSugar = new HashMap<>();
+        createSugarMaps();
+    }
+
+    private void createSugarMaps() {
+        grammarHasSugar = false;
+        ruleSugar.clear();
+        rhsDirectSugar.clear();
+        rhsNestedSugar.clear();
+
+        for (Rule rule : originalGrammar.getRules()) {
+            boolean ruleHasSugar = checkRule(rule);
+            grammarHasSugar = grammarHasSugar || ruleHasSugar;
+        }
+    }
+
+    private boolean checkRule(Rule rule) {
+        if (rule.isRegexRule() || rule.hasDependency()) {
+            ruleSugar.put(rule, false);
+            return false;
+        }
+        boolean hasSugar = checkDirectSugar(rule.rhs());
+        hasSugar = checkNestedSugar(rule.rhs()) || hasSugar;
+        ruleSugar.put(rule, hasSugar);
+        return hasSugar;
+    }
+
+    private boolean checkDirectSugar(RHSTree tree) {
+        boolean directSugar = tree.getKind() == RHSKind.SINGLE;
+        rhsDirectSugar.put(tree, directSugar);
+        return directSugar;
+    }
+
+    private boolean checkNestedSugar(RHSTree tree) {
+        if (rhsNestedSugar.containsKey(tree)) {
+            return rhsNestedSugar.get(tree);
+        }
+        // put this in here to avoid infinite recursion.
+        // I think the right value should end up in the map
+        // when everything is said and done.
+        rhsNestedSugar.put(tree, false);
+
+        boolean nestedSugar = false;
+        if (tree.getKind() == RHSKind.SINGLE || tree.getKind() == RHSKind.LIST) {
+            for (int i = 0; i < tree.size(); i++) {
+                RHSTree child = tree.getChild(i);
+                nestedSugar = checkDirectSugar(child);
+                nestedSugar = checkNestedSugar(child) || nestedSugar;
+            }
+        }
+
+        if (tree.getType() == RHSType.IDENTIFIER) {
+            nestedSugar = checkRule(tree.getLink());
+        }
+
+        rhsNestedSugar.put(tree, nestedSugar);
+        return nestedSugar;
+    }
+
+    @Override
+    public Grammar getOriginalGrammar() {
+        return originalGrammar;
+    }
+
+    @Override
+    public boolean containsAffectedRules() {
+        return grammarHasSugar;
+    }
+
+    @Override
+    public boolean isRuleAffected(Rule rule) {
+        return ruleSugar.get(rule);
+    }
+
+    @Override
+    public boolean isRHSAffected(Rule parent, RHSTree tree) {
+        return rhsDirectSugar.get(tree) || rhsNestedSugar.get(tree);
+    }
+
+    @Override
+    public Grammar getTransformedGrammar() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/java/src/main/java/com/blamedcloud/parsertongue/grammar/transformer/SugarTransformer.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/grammar/transformer/SugarTransformer.java
@@ -112,11 +112,11 @@ public class SugarTransformer implements GrammarTransformer {
         }
 
         if (originalGrammar.hasDependencies()) {
-            newGrammar = new Grammar(newRules, originalGrammar.getStartRule(), true);
+            newGrammar = new Grammar(newRules, originalGrammar.getStartRuleName(), true);
             newGrammar.setExternalRuleMaps(originalGrammar.getExternalRuleMaps());
             newGrammar.linkRules();
         } else {
-            newGrammar = new Grammar(newRules, originalGrammar.getStartRule(), false);
+            newGrammar = new Grammar(newRules, originalGrammar.getStartRuleName(), false);
         }
     }
 

--- a/java/src/main/java/com/blamedcloud/parsertongue/parser/Parser.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/parser/Parser.java
@@ -10,9 +10,9 @@ import java.util.Set;
 import java.util.function.Function;
 
 import com.blamedcloud.parsertongue.grammar.Grammar;
-import com.blamedcloud.parsertongue.grammar.ParseResult;
-import com.blamedcloud.parsertongue.grammar.ParseResultTransformer;
 import com.blamedcloud.parsertongue.grammar.dependencies.DependencyManager;
+import com.blamedcloud.parsertongue.grammar.result.ParseResult;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 import com.blamedcloud.parsertongue.tokenizer.TokenizerTypeList;
 

--- a/java/src/main/java/com/blamedcloud/parsertongue/tokenizer/TokenType.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/tokenizer/TokenType.java
@@ -42,6 +42,10 @@ public class TokenType {
         return typePattern;
     }
 
+    public String getExpression() {
+        return typeExpression;
+    }
+
     // technically two different patterns could yield the same regular language
     // but we choose not to care about that case.
     public boolean isSameAs(TokenType other) {

--- a/java/src/main/java/com/blamedcloud/parsertongue/tokenizer/Tokenizer.java
+++ b/java/src/main/java/com/blamedcloud/parsertongue/tokenizer/Tokenizer.java
@@ -51,6 +51,18 @@ public class Tokenizer {
         tokens = tokenList;
     }
 
+    public boolean hasSameTokens(Tokenizer other) {
+        if (tokens.size() != other.tokens.size()) {
+            return false;
+        }
+        for (int i = 0; i < tokens.size(); i++) {
+            if (!tokens.get(i).isSameAs(other.tokens.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public int size() {
         return tokens.size();
     }

--- a/java/src/test/java/com/blamedcloud/parsertongue/grammar/GrammarSaverTest.java
+++ b/java/src/test/java/com/blamedcloud/parsertongue/grammar/GrammarSaverTest.java
@@ -1,0 +1,52 @@
+package com.blamedcloud.parsertongue.grammar;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.Test;
+
+import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
+
+public class GrammarSaverTest {
+
+    @Test
+    public void testSimpleGrammar() throws Exception {
+        String filePath = "src/test/resources/b_aStar_c.ebnf";
+        testGrammar(filePath);
+    }
+
+    @Test
+    public void testComplexGrammar() throws Exception {
+        String filePath = "src/test/resources/testAllInternal.ebnf";
+        testGrammar(filePath);
+    }
+
+    private void testGrammar(String filePath) throws Exception {
+        Grammar grammar = getGrammar(filePath);
+        Tokenizer originalTokens = getTokensFromFile(filePath);
+
+        String savedGrammar = GrammarSaver.saveGrammar(grammar);
+        Tokenizer newTokens = getTokensFromString(savedGrammar);
+
+        assertTrue("The grammars should have the same tokens", originalTokens.hasSameTokens(newTokens));
+    }
+
+    private Grammar getGrammar(String path) throws Exception {
+        return Grammar.newBuilder(new File(path)).build();
+    }
+
+    private Tokenizer getTokensFromFile(String path) throws Exception {
+        File file = new File(path);
+        String fullText = Files.readString(file.toPath());
+        return getTokensFromString(fullText);
+    }
+
+    private Tokenizer getTokensFromString(String grammarString) throws Exception {
+        Tokenizer tokenizer = Grammar.newTokenizer();
+        tokenizer.tokenize(grammarString);
+        return tokenizer;
+    }
+
+}

--- a/java/src/test/java/com/blamedcloud/parsertongue/grammar/GrammarTest.java
+++ b/java/src/test/java/com/blamedcloud/parsertongue/grammar/GrammarTest.java
@@ -154,4 +154,5 @@ public class GrammarTest {
     private Grammar getGrammar(String path) throws Exception {
         return Grammar.newBuilder(new File(path)).build();
     }
+
 }

--- a/java/src/test/java/com/blamedcloud/parsertongue/grammar/RuleExpecteratorTest.java
+++ b/java/src/test/java/com/blamedcloud/parsertongue/grammar/RuleExpecteratorTest.java
@@ -216,7 +216,7 @@ public class RuleExpecteratorTest {
     }
 
     private Rule createRule(String ruleInput) {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         tokenizer.tokenize(ruleInput);
         Rule rule = new Rule(tokenizer);
         return rule;

--- a/java/src/test/java/com/blamedcloud/parsertongue/grammar/RuleExpecteratorTest.java
+++ b/java/src/test/java/com/blamedcloud/parsertongue/grammar/RuleExpecteratorTest.java
@@ -13,11 +13,11 @@ import java.util.Set;
 import org.junit.Test;
 
 import com.blamedcloud.parsertongue.grammar.expecterator.ParseResultExpecterator;
+import com.blamedcloud.parsertongue.grammar.result.ParseResultTransformer;
 import com.blamedcloud.parsertongue.tokenizer.Tokenizer;
 import com.blamedcloud.parsertongue.tokenizer.TokenizerTypeList;
 
 public class RuleExpecteratorTest {
-
 
     @Test
     public void simpleTerminalTest() {

--- a/java/src/test/java/com/blamedcloud/parsertongue/grammar/RuleTest.java
+++ b/java/src/test/java/com/blamedcloud/parsertongue/grammar/RuleTest.java
@@ -21,7 +21,7 @@ public class RuleTest {
 
     @Test
     public void externalRuleTest() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType identifierType = tokenizer.getTTL().get(IDENTIFIER_NAME);
 
         String ruleInput = "this = otherGrammar : that";
@@ -47,7 +47,7 @@ public class RuleTest {
 
     @Test
     public void regexRuleTest() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType identifierType = tokenizer.getTTL().get(IDENTIFIER_NAME);
 
         TokenType regexType = new TokenType("aManyB", "ab+");
@@ -73,7 +73,7 @@ public class RuleTest {
 
     @Test
     public void optionalRuleTest() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType identifierType = tokenizer.getTTL().get(IDENTIFIER_NAME);
         TokenType terminalType = tokenizer.getTTL().get(TERMINAL_NAME);
 
@@ -104,7 +104,7 @@ public class RuleTest {
 
     @Test
     public void repeatRuleTest() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType identifierType = tokenizer.getTTL().get(IDENTIFIER_NAME);
         TokenType terminalType = tokenizer.getTTL().get(TERMINAL_NAME);
 
@@ -135,7 +135,7 @@ public class RuleTest {
 
     @Test
     public void groupRuleTest() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType identifierType = tokenizer.getTTL().get(IDENTIFIER_NAME);
         TokenType terminalType = tokenizer.getTTL().get(TERMINAL_NAME);
 
@@ -166,7 +166,7 @@ public class RuleTest {
 
     @Test
     public void alternationRuleTest() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType identifierType = tokenizer.getTTL().get(IDENTIFIER_NAME);
         TokenType terminalType = tokenizer.getTTL().get(TERMINAL_NAME);
 
@@ -213,7 +213,7 @@ public class RuleTest {
 
     @Test
     public void concatenationRuleTest() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType identifierType = tokenizer.getTTL().get(IDENTIFIER_NAME);
         TokenType terminalType = tokenizer.getTTL().get(TERMINAL_NAME);
 
@@ -267,7 +267,7 @@ public class RuleTest {
 
     @Test
     public void complexRuleTest() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType identifierType = tokenizer.getTTL().get(IDENTIFIER_NAME);
         TokenType terminalType = tokenizer.getTTL().get(TERMINAL_NAME);
 

--- a/java/src/test/java/com/blamedcloud/parsertongue/grammar/SugarTest.java
+++ b/java/src/test/java/com/blamedcloud/parsertongue/grammar/SugarTest.java
@@ -1,0 +1,34 @@
+package com.blamedcloud.parsertongue.grammar;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Test;
+
+
+public class SugarTest {
+
+    @Test
+    public void testGrammarNoSugar() throws Exception {
+        Grammar grammar = getGrammar("src/test/resources/aToN.ebnf");
+        assertFalse(grammar.hasSugar());
+    }
+
+    @Test
+    public void testGrammarSugar() throws Exception {
+        Grammar grammar = getGrammar("src/test/resources/b_aStar_c.ebnf");
+        assertTrue(grammar.hasSugar());
+    }
+
+    @Test
+    public void testComplexGrammarSugar() throws Exception {
+        Grammar grammar = getGrammar("src/test/resources/testAllInternal.ebnf");
+        assertTrue(grammar.hasSugar());
+    }
+
+    private Grammar getGrammar(String path) throws Exception {
+        return Grammar.newBuilder(new File(path)).build();
+    }
+}

--- a/java/src/test/java/com/blamedcloud/parsertongue/grammar/SugarTest.java
+++ b/java/src/test/java/com/blamedcloud/parsertongue/grammar/SugarTest.java
@@ -7,25 +7,29 @@ import java.io.File;
 
 import org.junit.Test;
 
+import com.blamedcloud.parsertongue.grammar.transformer.SugarTransformer;
 
 public class SugarTest {
 
     @Test
     public void testGrammarNoSugar() throws Exception {
         Grammar grammar = getGrammar("src/test/resources/aToN.ebnf");
-        assertFalse(grammar.hasSugar());
+        SugarTransformer sugar = new SugarTransformer(grammar);
+        assertFalse(sugar.containsAffectedRules());
     }
 
     @Test
     public void testGrammarSugar() throws Exception {
         Grammar grammar = getGrammar("src/test/resources/b_aStar_c.ebnf");
-        assertTrue(grammar.hasSugar());
+        SugarTransformer sugar = new SugarTransformer(grammar);
+        assertTrue(sugar.containsAffectedRules());
     }
 
     @Test
     public void testComplexGrammarSugar() throws Exception {
         Grammar grammar = getGrammar("src/test/resources/testAllInternal.ebnf");
-        assertTrue(grammar.hasSugar());
+        SugarTransformer sugar = new SugarTransformer(grammar);
+        assertTrue(sugar.containsAffectedRules());
     }
 
     private Grammar getGrammar(String path) throws Exception {

--- a/java/src/test/java/com/blamedcloud/parsertongue/grammar/SugarTest.java
+++ b/java/src/test/java/com/blamedcloud/parsertongue/grammar/SugarTest.java
@@ -1,15 +1,19 @@
 package com.blamedcloud.parsertongue.grammar;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.Map;
 
 import org.junit.Test;
 
 import com.blamedcloud.parsertongue.grammar.transformer.SugarTransformer;
 
 public class SugarTest {
+
+    private static final int TEST_ITERATIONS = 200;
 
     @Test
     public void testGrammarNoSugar() throws Exception {
@@ -23,6 +27,12 @@ public class SugarTest {
         Grammar grammar = getGrammar("src/test/resources/b_aStar_c.ebnf");
         SugarTransformer sugar = new SugarTransformer(grammar);
         assertTrue(sugar.containsAffectedRules());
+
+        Grammar newGrammar = sugar.getTransformedGrammar();
+        SugarTransformer newSugar = new SugarTransformer(newGrammar);
+        assertFalse(newSugar.containsAffectedRules());
+
+        compareGrammars(grammar, newGrammar);
     }
 
     @Test
@@ -30,9 +40,21 @@ public class SugarTest {
         Grammar grammar = getGrammar("src/test/resources/testAllInternal.ebnf");
         SugarTransformer sugar = new SugarTransformer(grammar);
         assertTrue(sugar.containsAffectedRules());
+
+        Grammar newGrammar = sugar.getTransformedGrammar();
+        SugarTransformer newSugar = new SugarTransformer(newGrammar);
+        assertFalse(newSugar.containsAffectedRules());
+
+        compareGrammars(grammar, newGrammar);
     }
 
     private Grammar getGrammar(String path) throws Exception {
         return Grammar.newBuilder(new File(path)).build();
+    }
+
+    private void compareGrammars(Grammar oldGrammar, Grammar newGrammar) throws Exception {
+        Map<String, Boolean> oldClassification = oldGrammar.classifyFirstNStrings(TEST_ITERATIONS);
+        Map<String, Boolean> newClassification = newGrammar.classifyFirstNStrings(TEST_ITERATIONS);
+        assertEquals("The classifications should be the same", oldClassification, newClassification);
     }
 }

--- a/java/src/test/java/com/blamedcloud/parsertongue/tokenizer/GrammarTTLTest.java
+++ b/java/src/test/java/com/blamedcloud/parsertongue/tokenizer/GrammarTTLTest.java
@@ -14,11 +14,13 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.blamedcloud.parsertongue.grammar.Grammar;
+
 public class GrammarTTLTest {
 
     @Test
     public void TestControl() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType controlType = tokenizer.getTTL().get(CONTROL_NAME);
 
         String input = "[[(|,}){]";
@@ -34,7 +36,7 @@ public class GrammarTTLTest {
 
     @Test
     public void TestIdentifier() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType identifierType = tokenizer.getTTL().get(IDENTIFIER_NAME);
 
         String input = "identifier,Id_2_special anotherOne";
@@ -63,7 +65,7 @@ public class GrammarTTLTest {
 
     @Test
     public void TestTerminal() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType terminalType = tokenizer.getTTL().get(TERMINAL_NAME);
 
         String input = "'simple' \n \t 'single \"quoted\" string' \"double quoted string with 'single quotes'\"";
@@ -88,7 +90,7 @@ public class GrammarTTLTest {
 
     @Test
     public void TestComment() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType commentType = tokenizer.getTTL().get(COMMENT_NAME);
 
         String input = "stuff = 'a' | { 'b' # comment\n } ;#another comment";
@@ -105,7 +107,7 @@ public class GrammarTTLTest {
 
     @Test
     public void TestOthers() {
-        Tokenizer tokenizer = new Tokenizer();
+        Tokenizer tokenizer = Grammar.newTokenizer();
         TokenType endType = tokenizer.getTTL().get(END_NAME);
         TokenType defineType = tokenizer.getTTL().get(DEFINE_NAME);
         TokenType externalType = tokenizer.getTTL().get(EXTERNAL_NAME);

--- a/java/src/test/resources/testAllInternal.ebnf
+++ b/java/src/test/resources/testAllInternal.ebnf
@@ -1,6 +1,6 @@
 
 # test one of the following languages, prepend each with a number to differentiate them.
-start = '1' , test1 | '2' , test2 | '3' , test3 | '4' , test4 | '5' , test5 | '6' , test6;
+start = '1' , test1 | '2' , test2 | '3' , test3 | '4' , test4 | '5' , test5 | '6' , test6 | '7' , test7;
 
 # a^n b^n . classic example
 test1 = "a" , test1 , "b" | "" ;
@@ -23,3 +23,6 @@ test5 = [equal];
 
 # ba*c
 test6 = 'b', ({'a'}, 'c');
+
+# a regex test
+test7 = ~ 'b(ab?c*)*';


### PR DESCRIPTION
Creates the GrammarTransformer interface, as well as SugarTransformer that implements it. SugarTransformer is for removing syntactic sugar from a Grammar, namely the group, optional, and repeat grammar constructions.

Moves the ParseResult and related classes into a new subpackage, grammar.result, within the grammar package.

Creates a GrammarSaver for saving a grammar to a string, which is useful for saving a grammar after applying a GrammarTransformer to it.